### PR TITLE
Remove opacity from tvState if view is opaque or forceNonFade is passed

### DIFF
--- a/Sources/Preprocessors/MatchPreprocessor.swift
+++ b/Sources/Preprocessors/MatchPreprocessor.swift
@@ -61,6 +61,7 @@ class MatchPreprocessor: BasePreprocessor {
         } else {
           // no cross fade in this case, fromView is always displayed during the transition.
           fvState.opacity = nil
+          tvState.opacity = nil
 
           // we dont want two shadows showing up. Therefore we disable toView's shadow when fromView is able to display its shadow
           if !fv.layer.masksToBounds && fvState.displayShadow {


### PR DESCRIPTION
Hi folks!

Some time ago I encountered [an issue](https://github.com/lkzhao/Hero/issues/385) regarding additional opacity transition that shouldn't happen. The bug was about incorrect `tvState.opacity` (which was `0` by default), so I fixed it in this PR.

New behavior: if `forceNonFade` is passed or view has `isOpaque` property set to true, don't set opacity of the target view to zero.

Please, let me know if you have any kind of suggestions or concerns.