### PR TITLE
fix keyboard transition

### DIFF
--- a/Sources/Transition/HeroTransition+Start.swift
+++ b/Sources/Transition/HeroTransition+Start.swift
@@ -91,6 +91,7 @@ extension HeroTransition {
 
     // a view to hold all the animating views
     container = UIView(frame: transitionContainer?.bounds ?? .zero)
+    container.isUserInteractionEnabled = false
     if !toOverFullScreen && !fromOverFullScreen {
       container.backgroundColor = containerColor
     }


### PR DESCRIPTION
Create an UINavigationController with hero enabled that contains 2 viewcontrollers (push), each controller call a textinput to become first responder in its viewWillAppear (ex: textfield.becomeFirstResponder()).
Before the fix: keyboard dismiss and then reappear while transition
After the fix: clean transition