### PR TITLE
Hidden subviews not taken into account in optimized snapshot type

### DIFF
--- a/Sources/HeroContext.swift
+++ b/Sources/HeroContext.swift
@@ -174,7 +174,7 @@ extension HeroContext {
       #else
         if #available(iOS 9.0, *), let stackView = view as? UIStackView {
           snapshot = stackView.slowSnapshotView()
-        } else if let imageView = view as? UIImageView, view.subviews.isEmpty {
+        } else if let imageView = view as? UIImageView, view.subviews.filter({!$0.isHidden}).isEmpty {
           let contentView = UIImageView(image: imageView.image)
           contentView.frame = imageView.bounds
           contentView.contentMode = imageView.contentMode

--- a/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
+++ b/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
@@ -249,9 +249,17 @@ class DefaultAnimationPreprocessor: BasePreprocessor {
       if animators.contains(where: { $0.canAnimate(view: toView, appearing: true) || $0.canAnimate(view: fromView, appearing: false) }) {
         defaultAnimation = .none
       } else if inNavigationController {
-        defaultAnimation = presenting ? .push(direction:.left) : .pull(direction:.right)
+        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+          defaultAnimation = presenting ? .push(direction:.left) : .pull(direction:.right)
+        } else {
+          defaultAnimation = presenting ? .push(direction:.right) : .pull(direction:.left)
+        }
       } else if inTabBarController {
-        defaultAnimation = presenting ? .slide(direction:.left) : .slide(direction:.right)
+        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+          defaultAnimation = presenting ? .slide(direction:.left) : .slide(direction:.right)
+        } else {
+          defaultAnimation = presenting ? .slide(direction:.right) : .slide(direction:.left)
+        }
       } else {
         defaultAnimation = .fade
       }


### PR DESCRIPTION
When using `.optimized` snapshot type in a `UIImageView`, the optimized snapshot is ignored if the image view contains at least one subview. This PR change that behavior slightly: it just takes the subviews into account if they are not hidden. So, image views with subviews where all subviews are hidden can still use the optimized snapshot type. 