### PR TITLE
Dont store strong references to Navigation and TabBarController delegates

### DIFF
--- a/Sources/Extensions/UIViewController+Hero.swift
+++ b/Sources/Extensions/UIViewController+Hero.swift
@@ -28,8 +28,8 @@ internal class HeroViewControllerConfig: NSObject {
   var tabBarAnimation: HeroDefaultAnimationType = .auto
 
   var storedSnapshot: UIView?
-  var previousNavigationDelegate: UINavigationControllerDelegate?
-  var previousTabBarDelegate: UITabBarControllerDelegate?
+  weak var previousNavigationDelegate: UINavigationControllerDelegate?
+  weak var previousTabBarDelegate: UITabBarControllerDelegate?
 }
 
 extension UIViewController: HeroCompatible { }


### PR DESCRIPTION
Holding strong references leads to reference cycles if the delegate is set to self.

Fixes: #515 