### PR TITLE
Keep using default navigation animation direction with RTL languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@ The changelog for `Hero`. Also see the [releases](https://github.com/HeroTransit
 
 ## Upcoming release
 
+### Changed
+
+- Added support for right to left languages.
+[#520](https://github.com/HeroTransitions/Hero/pull/520) by [@ManueGE](https://github.com/ManueGE)
+
 ## [1.4.0](https://github.com/HeroTransitions/Hero/releases/tag/1.4.0)
 
 ### Added
 
 - Added support for Swift 4.2.
 [#534](https://github.com/HeroTransitions/Hero/pull/534) by [@rennarda](https://github.com/rennarda)
-
-### Changed
-
-- Added support for right to left languages.
-[#520](https://github.com/HeroTransitions/Hero/pull/520) by [@ManueGE](https://github.com/ManueGE)
 
 ## [1.3.1](https://github.com/HeroTransitions/Hero/releases/tag/1.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The changelog for `Hero`. Also see the [releases](https://github.com/HeroTransit
 - Added support for Swift 4.2.
 [#534](https://github.com/HeroTransitions/Hero/pull/534) by [@rennarda](https://github.com/rennarda)
 
+### Changed
+
+- Added support for right to left languages.
+[#520](https://github.com/HeroTransitions/Hero/pull/520) by [@ManueGE](https://github.com/ManueGE)
+
 ## [1.3.1](https://github.com/HeroTransitions/Hero/releases/tag/1.3.1)
 
 ### Fixed

--- a/Sources/Preprocessors/CascadePreprocessor.swift
+++ b/Sources/Preprocessors/CascadePreprocessor.swift
@@ -62,9 +62,21 @@ public enum CascadeDirection {
       self = .rightToLeft
     case "topToBottom":
       self = .topToBottom
+    case "leadingToTrailing":
+      self = .leadingToTrailing
+    case "trailingToLeading":
+      self = .trailingToLeading
     default:
       return nil
     }
+  }
+  
+  public static var leadingToTrailing: CascadeDirection {
+    return UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? .leftToRight : .rightToLeft
+  }
+  
+  public static var trailingToLeading: CascadeDirection {
+    return UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? .rightToLeft : .leftToRight
   }
 
   private func topToBottomComperator(lhs: UIView, rhs: UIView) -> Bool {

--- a/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
+++ b/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
@@ -31,8 +31,18 @@ public enum HeroDefaultAnimationType {
       case "right": return .right
       case "up": return .up
       case "down": return .down
+      case "leading": return .leading
+      case "trailing": return .trailing
       default: return nil
       }
+    }
+    
+    public static var leading: Direction {
+      return UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? .left : .right
+    }
+    
+    public static var trailing: Direction {
+      return UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? .right : .left
     }
   }
   case auto
@@ -249,17 +259,9 @@ class DefaultAnimationPreprocessor: BasePreprocessor {
       if animators.contains(where: { $0.canAnimate(view: toView, appearing: true) || $0.canAnimate(view: fromView, appearing: false) }) {
         defaultAnimation = .none
       } else if inNavigationController {
-        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
-          defaultAnimation = presenting ? .push(direction:.left) : .pull(direction:.right)
-        } else {
-          defaultAnimation = presenting ? .push(direction:.right) : .pull(direction:.left)
-        }
+        defaultAnimation = presenting ? .push(direction:.leading) : .pull(direction:.trailing)
       } else if inTabBarController {
-        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
-          defaultAnimation = presenting ? .slide(direction:.left) : .slide(direction:.right)
-        } else {
-          defaultAnimation = presenting ? .slide(direction:.right) : .slide(direction:.left)
-        }
+        defaultAnimation = presenting ? .push(direction:.leading) : .pull(direction:.trailing)
       } else {
         defaultAnimation = .fade
       }

--- a/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
+++ b/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
@@ -45,6 +45,21 @@ public enum HeroDefaultAnimationType {
       return UIApplication.shared.userInterfaceLayoutDirection == .leftToRight ? .right : .left
     }
   }
+  
+  public enum Strategy {
+    case forceLeftToRight, forceRightToLeft, userInterface
+    func defaultDirection(presenting: Bool) -> Direction {
+      switch self {
+      case .forceLeftToRight:
+        return presenting ? .left : .right
+      case .forceRightToLeft:
+        return presenting ? .right : .left
+      case .userInterface:
+        return presenting ? .leading : .trailing
+      }
+    }
+  }
+  
   case auto
   case push(direction: Direction)
   case pull(direction: Direction)
@@ -259,9 +274,11 @@ class DefaultAnimationPreprocessor: BasePreprocessor {
       if animators.contains(where: { $0.canAnimate(view: toView, appearing: true) || $0.canAnimate(view: fromView, appearing: false) }) {
         defaultAnimation = .none
       } else if inNavigationController {
-        defaultAnimation = presenting ? .push(direction:.leading) : .pull(direction:.trailing)
+        let direction = hero.defaultAnimationDirectionStrategy.defaultDirection(presenting: presenting)
+        defaultAnimation = .push(direction: direction)
       } else if inTabBarController {
-        defaultAnimation = presenting ? .slide(direction:.leading) : .slide(direction:.trailing)
+        let direction = hero.defaultAnimationDirectionStrategy.defaultDirection(presenting: presenting)
+        defaultAnimation = .slide(direction: direction)
       } else {
         defaultAnimation = .fade
       }

--- a/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
+++ b/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
@@ -249,9 +249,17 @@ class DefaultAnimationPreprocessor: BasePreprocessor {
       if animators.contains(where: { $0.canAnimate(view: toView, appearing: true) || $0.canAnimate(view: fromView, appearing: false) }) {
         defaultAnimation = .none
       } else if inNavigationController {
-        defaultAnimation = presenting ? .push(direction:.left) : .pull(direction:.right)
+        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+          defaultAnimation = presenting ? .push(direction:.left) : .pull(direction:.right)
+        } else {
+          defaultAnimation = presenting ? .push(direction:.right) : .pull(direction:.left)
+        }
       } else if inTabBarController {
-        defaultAnimation = presenting ? .slide(direction:.left) : .slide(direction:.right)
+        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+          defaultAnimation = presenting ? .slide(direction:.left) : .slide(direction:.right)
+        } else {
+          defaultAnimation = presenting ? .slide(direction:.right) : .slide(direction:.left)
+        }
       } else {
         defaultAnimation = .fade
       }

--- a/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
+++ b/Sources/Preprocessors/DefaultAnimationPreprocessor.swift
@@ -261,7 +261,7 @@ class DefaultAnimationPreprocessor: BasePreprocessor {
       } else if inNavigationController {
         defaultAnimation = presenting ? .push(direction:.leading) : .pull(direction:.trailing)
       } else if inTabBarController {
-        defaultAnimation = presenting ? .push(direction:.leading) : .pull(direction:.trailing)
+        defaultAnimation = presenting ? .slide(direction:.leading) : .slide(direction:.trailing)
       } else {
         defaultAnimation = .fade
       }

--- a/Sources/Transition/HeroTransition.swift
+++ b/Sources/Transition/HeroTransition.swift
@@ -55,6 +55,7 @@ open class HeroTransition: NSObject {
   public var containerColor: UIColor = .black
   public var isUserInteractionEnabled = false
   public var viewOrderingStrategy: HeroViewOrderingStrategy = .auto
+  public var defaultAnimationDirectionStrategy: HeroDefaultAnimationType.Strategy = .forceLeftToRight
 
   public internal(set) var state: HeroTransitionState = .possible {
     didSet {


### PR DESCRIPTION
If the user is using an RTL (right to left) language, the navigation controller is expected to use the inverse transition directions by default: `.right` for pushing and `.left` for popping. 

Currently, it is not working, and the navigation controllers behave as it does in LTR languages. 

This commit fixes this issue.