### PR TITLE
Hidden subviews not taken in account in optimized snapshot type

### DIFF
--- a/Sources/HeroContext.swift
+++ b/Sources/HeroContext.swift
@@ -174,7 +174,7 @@ extension HeroContext {
       #else
         if #available(iOS 9.0, *), let stackView = view as? UIStackView {
           snapshot = stackView.slowSnapshotView()
-        } else if let imageView = view as? UIImageView, view.subviews.isEmpty {
+        } else if let imageView = view as? UIImageView, view.subviews.filter({!$0.isHidden}).isEmpty {
           let contentView = UIImageView(image: imageView.image)
           contentView.frame = imageView.bounds
           contentView.contentMode = imageView.contentMode


### PR DESCRIPTION
When using `.optimized` snapshot type in a `UIImageView`, the optimized snapshot is ignored if the image view contains at least one subview. This PR change that behavior slightly: it just takes the subviews into account if they are not hidden. So, image views with subviews where all subviews are hidden can still use the optimized snapshot type.