### PR TITLE
Use custom snapshot for views that implements HeroCustomSnapshotView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ The changelog for `Hero`. Also see the [releases](https://github.com/HeroTransit
 
 ## Upcoming release
 
+### Added
+
+- Use custom snapshot for views that implement `HeroCustomSnapshotView`.
+[#541](https://github.com/HeroTransitions/Hero/pull/541) by [@ManueGE](https://github.com/ManueGE)
+
 ## [1.4.0](https://github.com/HeroTransitions/Hero/releases/tag/1.4.0)
 
 ### Added
 
 - Added support for Swift 4.2.
 [#534](https://github.com/HeroTransitions/Hero/pull/534) by [@rennarda](https://github.com/rennarda)
-
-- Use custom snapshot for views that implements `HeroCustomSnapshotView`.
-[#541](https://github.com/HeroTransitions/Hero/pull/541) by [@ManueGE](https://github.com/ManueGE)
 
 
 ## [1.3.1](https://github.com/HeroTransitions/Hero/releases/tag/1.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The changelog for `Hero`. Also see the [releases](https://github.com/HeroTransit
 - Added support for Swift 4.2.
 [#534](https://github.com/HeroTransitions/Hero/pull/534) by [@rennarda](https://github.com/rennarda)
 
+- Use custom snapshot for views that implements `HeroCustomSnapshotView`.
+[#541](https://github.com/HeroTransitions/Hero/pull/541) by [@ManueGE](https://github.com/ManueGE)
+
+
 ## [1.3.1](https://github.com/HeroTransitions/Hero/releases/tag/1.3.1)
 
 ### Fixed

--- a/Sources/HeroContext.swift
+++ b/Sources/HeroContext.swift
@@ -172,7 +172,9 @@ extension HeroContext {
       #if os(tvOS)
         snapshot = view.snapshotView(afterScreenUpdates: true)!
       #else
-        if #available(iOS 9.0, *), let stackView = view as? UIStackView {
+        if let customSnapshotView = view as? HeroCustomSnapshotView, let snapshotView = customSnapshotView.heroSnapshot {
+          snapshot = snapshotView
+        } else if #available(iOS 9.0, *), let stackView = view as? UIStackView {
           snapshot = stackView.slowSnapshotView()
         } else if let imageView = view as? UIImageView, view.subviews.isEmpty {
           let contentView = UIImageView(image: imageView.image)
@@ -387,4 +389,9 @@ extension HeroContext {
       storeViewAlpha(rootView: subview)
     }
   }
+}
+
+/// Allows a view to create their own custom snapshot when using **Optimized** snapshot
+public protocol HeroCustomSnapshotView {
+	var heroSnapshot: UIView? { get }
 }


### PR DESCRIPTION
I found very useful the **Optimized** snapshots for `UIImageView`, `UIStackView`, `Bars`, ... 

But at some point, I found myself needing my custom views a customized snapshot. To solve this issue, I created the `HeroCustomSnapshotView` protocol, that a view can implement in order to provide their own **optimized** snapshot. It has no impact in the rest of the library, but it can make it a little more flexible. 

If you like the idea but you'd like to use a better wording or a different approach, let me know, I'll be happy to help. 