### PR TITLE
Enables application extension API only

### DIFF
--- a/Hero.xcodeproj/project.pbxproj
+++ b/Hero.xcodeproj/project.pbxproj
@@ -1199,6 +1199,7 @@
 		2D1F7FC41E49DCB5004D944B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1226,6 +1227,7 @@
 		2D1F7FC51E49DCB5004D944B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1290,6 +1292,7 @@
 		A306D3BC1E1C7A2E00B6C23A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1317,6 +1320,7 @@
 		A306D3BD1E1C7A2E00B6C23A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;

--- a/Sources/Extensions/UIViewController+Hero.swift
+++ b/Sources/Extensions/UIViewController+Hero.swift
@@ -324,7 +324,9 @@ public extension HeroExtension where Base: UIViewController {
             parentVC.present(next, animated: false, completion: completion)
           }
         } else {
+          #if TARGET_IS_EXTENSION
           UIApplication.shared.keyWindow?.rootViewController = next
+          #endif
         }
       }
     }

--- a/Sources/Transition/HeroTransition+Complete.swift
+++ b/Sources/Transition/HeroTransition+Complete.swift
@@ -87,7 +87,9 @@ extension HeroTransition {
       if isPresenting != finished, !inContainerController, transitionContext != nil {
         // only happens when present a .overFullScreen VC
         // bug: http://openradar.appspot.com/radar?id=5320103646199808
+        #if TARGET_IS_EXTENSION
         UIApplication.shared.keyWindow?.addSubview(isPresenting ? fromView : toView)
+        #endif
       }
     }
 


### PR DESCRIPTION
Adds support for using Hero in application extension. 

Due to two workarounds which use `Application.shared`, which is unavailable inside of extension we needed do insert conditional compile mark. We hope this works and would like to get some feedback.