### PR TITLE
Resuming property animator from current fraction

### DIFF
--- a/Sources/Animator/HeroViewPropertyViewContext.swift
+++ b/Sources/Animator/HeroViewPropertyViewContext.swift
@@ -38,11 +38,22 @@ internal class HeroViewPropertyViewContext: HeroAnimatorViewContext {
     if reverse {
       viewPropertyAnimator?.stopAnimation(false)
       viewPropertyAnimator?.finishAnimation(at: .current)
+      
       viewPropertyAnimator = UIViewPropertyAnimator(duration: duration, curve: .linear) {
         visualEffectView.effect = reverse ? self.startEffect : self.endEffect
       }
+      
+      // workaround for a bug https://openradar.appspot.com/30856746
+      viewPropertyAnimator.startAnimation()
+      viewPropertyAnimator.pauseAnimation()
+        
+      viewPropertyAnimator.fractionComplete = CGFloat(1.0 - timePassed / duration)
     }
-    viewPropertyAnimator.startAnimation()
+    
+    DispatchQueue.main.async {
+      self.viewPropertyAnimator.startAnimation()
+    }
+    
     return duration
   }
 


### PR DESCRIPTION
If you call `Hero.shared.cancel()`, UIVisualEffectView starts animation from scratch instead of the current fraction value. This commit fixed this issue.