### PR TITLE
Use more minimal import

### DIFF
--- a/Sources/Extensions/CG+Hero.swift
+++ b/Sources/Extensions/CG+Hero.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import MetalKit
+import QuartzCore
 
 let π = CGFloat.pi
 


### PR DESCRIPTION
This will have a minor benefit on app size for apps that don't use MetalKit since libswiftMetalKit.dylib will no longer be bundled.