### PR TITLE
Fix undesired navigation / tab bar controller state

### DIFF
--- a/Sources/Extensions/UIViewController+Hero.swift
+++ b/Sources/Extensions/UIViewController+Hero.swift
@@ -68,7 +68,14 @@ public extension HeroExtension where Base: UIViewController {
   // TODO: can be moved to internal later (will still be accessible via IB)
   public var isEnabled: Bool {
     get {
-      return base.transitioningDelegate is HeroTransition
+      let isTransitioningDelegate = base.transitioningDelegate is HeroTransition
+      if let navi = base as? UINavigationController {
+        return navi.delegate is HeroTransition && isTransitioningDelegate
+      }
+      if let tab = base as? UITabBarController {
+        return tab.delegate is HeroTransition && isTransitioningDelegate
+      }
+      return isTransitioningDelegate
     }
     set {
       guard newValue != isEnabled else { return }

--- a/Sources/Extensions/UIViewController+Hero.swift
+++ b/Sources/Extensions/UIViewController+Hero.swift
@@ -76,7 +76,14 @@ public extension HeroExtension where Base: UIViewController {
         return tab.delegate is HeroTransition && isTransitioningDelegate
       }
       return isTransitioningDelegate
-    }
+	  switch base {
+	  	case let navi as UINavigationController: 
+	  	    return navi.delegate is HeroTransition && isTransitioningDelegate
+	    case let tab as UITabBarController: 
+	  	    return tab.delegate is HeroTransition && isTransitioningDelegate
+	  	default:
+	  	    return isTransitioningDelegate
+	  }
     set {
       guard newValue != isEnabled else { return }
       if newValue {

--- a/Sources/Transition/HeroTransition+Start.swift
+++ b/Sources/Transition/HeroTransition+Start.swift
@@ -91,6 +91,7 @@ extension HeroTransition {
 
     // a view to hold all the animating views
     container = UIView(frame: transitionContainer?.bounds ?? .zero)
+    container.isUserInteractionEnabled = false
     if !toOverFullScreen && !fromOverFullScreen {
       container.backgroundColor = containerColor
     }


### PR DESCRIPTION
Setting the delegate of a navigation or tab bar controller after enabling hero on the same controller leaves the controller in an undesirable state.

1. Setting hero.isEnabled on the navigation or tab bar controller will set the transitioning delegate and delegate of the controller to Hero.shared.
2. Getting hero.isEnabled on the same controller only checks if the transitioning delegate is set correctly.
3. Consequently, setting the delegate of a navigation or tab bar controller after enabling hero on the same controller will disable some hero functionality even though hero.isEnabled still returns true (which can be confusing and misleading).
4. Additionally, setting hero.isEnabled to true again after setting the navigation or tab bar controllers delegate has no effect, since hero.isEnabled is already true and the setter implementation guards for newValue != oldValue.

This pull requests implements a solution for the aforementioned issue, by validating the state of the navigation or tab bar controller delegate in the hero.isEnabled getter. This will make the getter reflect more correctly the state of navigation and tab bar controllers, while also fixing the issue of allowing hero to be reenabled.