### PR TITLE
Respect `maskedCorners` for snapshots on iOS 11+

### DIFF
--- a/Sources/HeroContext.swift
+++ b/Sources/HeroContext.swift
@@ -139,6 +139,13 @@ extension HeroContext {
     unhide(view: view)
 
     // capture a snapshot without alpha, cornerRadius, or shadows
+    let oldMaskedCorners: CACornerMask = {
+      if #available(iOS 11, *) {
+        return view.layer.maskedCorners
+      } else {
+        return []
+      }
+    }()
     let oldCornerRadius = view.layer.cornerRadius
     let oldAlpha = view.alpha
 		let oldShadowRadius = view.layer.shadowRadius
@@ -218,6 +225,9 @@ extension HeroContext {
       }
     #endif
 
+    if #available(iOS 11, *) {
+      view.layer.maskedCorners = oldMaskedCorners
+    }
     view.layer.cornerRadius = oldCornerRadius
     view.alpha = oldAlpha
 		view.layer.shadowRadius = oldShadowRadius
@@ -235,12 +245,18 @@ extension HeroContext {
       if !(view is UINavigationBar), let contentView = snapshot.subviews.get(0) {
         // the Snapshot's contentView must have hold the cornerRadius value,
         // since the snapshot might not have maskToBounds set
+        if #available(iOS 11, *) {
+          contentView.layer.maskedCorners = view.layer.maskedCorners
+        }
         contentView.layer.cornerRadius = view.layer.cornerRadius
         contentView.layer.masksToBounds = true
       }
 
-      snapshot.layer.allowsGroupOpacity = false
+      if #available(iOS 11, *) {
+        snapshot.layer.maskedCorners = view.layer.maskedCorners
+      }
       snapshot.layer.cornerRadius = view.layer.cornerRadius
+      snapshot.layer.allowsGroupOpacity = false
       snapshot.layer.zPosition = view.layer.zPosition
       snapshot.layer.opacity = view.layer.opacity
       snapshot.layer.isOpaque = view.layer.isOpaque


### PR DESCRIPTION
Currently when taking a snapshot of a layer with `maskedCorners` set, Hero ignores this property and rounds all of the corners. This PR fixes this by applying the `maskedCorners` property to the snapshot views on iOS 11+.