### PR TITLE
Remove access modifier warnings

### DIFF
--- a/Sources/Extensions/CAMediaTimingFunction+Hero.swift
+++ b/Sources/Extensions/CAMediaTimingFunction+Hero.swift
@@ -24,19 +24,19 @@ import UIKit
 
 public extension CAMediaTimingFunction {
   // default
-  public static let linear = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
-  public static let easeIn = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
-  public static let easeOut = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
-  public static let easeInOut = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+  static let linear = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
+  static let easeIn = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
+  static let easeOut = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
+  static let easeInOut = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
 
   // material
-  public static let standard = CAMediaTimingFunction(controlPoints: 0.4, 0.0, 0.2, 1.0)
-  public static let deceleration = CAMediaTimingFunction(controlPoints: 0.0, 0.0, 0.2, 1)
-  public static let acceleration = CAMediaTimingFunction(controlPoints: 0.4, 0.0, 1, 1)
-  public static let sharp = CAMediaTimingFunction(controlPoints: 0.4, 0.0, 0.6, 1)
+  static let standard = CAMediaTimingFunction(controlPoints: 0.4, 0.0, 0.2, 1.0)
+  static let deceleration = CAMediaTimingFunction(controlPoints: 0.0, 0.0, 0.2, 1)
+  static let acceleration = CAMediaTimingFunction(controlPoints: 0.4, 0.0, 1, 1)
+  static let sharp = CAMediaTimingFunction(controlPoints: 0.4, 0.0, 0.6, 1)
 
   // easing.net
-  public static let easeOutBack = CAMediaTimingFunction(controlPoints: 0.175, 0.885, 0.32, 1.275)
+  static let easeOutBack = CAMediaTimingFunction(controlPoints: 0.175, 0.885, 0.32, 1.275)
 
   static func from(name: String) -> CAMediaTimingFunction? {
     switch name {

--- a/Sources/Extensions/CG+Hero.swift
+++ b/Sources/Extensions/CG+Hero.swift
@@ -40,25 +40,25 @@ internal struct KeySet<Key: Hashable, Value: Hashable> {
 }
 
 internal extension CGSize {
-  internal var center: CGPoint {
+  var center: CGPoint {
     return CGPoint(x: width / 2, y: height / 2)
   }
-  internal var point: CGPoint {
+  var point: CGPoint {
     return CGPoint(x: width, y: height)
   }
-  internal func transform(_ t: CGAffineTransform) -> CGSize {
+  func transform(_ t: CGAffineTransform) -> CGSize {
     return self.applying(t)
   }
-  internal func transform(_ t: CATransform3D) -> CGSize {
+  func transform(_ t: CATransform3D) -> CGSize {
     return self.applying(CATransform3DGetAffineTransform(t))
   }
 }
 
 internal extension CGRect {
-  internal var center: CGPoint {
+  var center: CGPoint {
     return CGPoint(x: origin.x + width / 2, y: origin.y + height / 2)
   }
-  internal var bounds: CGRect {
+  var bounds: CGRect {
     return CGRect(origin: CGPoint.zero, size: size)
   }
   init(center: CGPoint, size: CGSize) {
@@ -66,81 +66,83 @@ internal extension CGRect {
   }
 }
 
-extension CGFloat {
-  internal func clamp(_ a: CGFloat, _ b: CGFloat) -> CGFloat {
+internal extension CGFloat {
+  func clamp(_ a: CGFloat, _ b: CGFloat) -> CGFloat {
     return self < a ? a : (self > b ? b : self)
   }
 }
-extension TimeInterval {
-  internal func clamp(_ a: TimeInterval, _ b: TimeInterval) -> TimeInterval {
+
+internal extension TimeInterval {
+  func clamp(_ a: TimeInterval, _ b: TimeInterval) -> TimeInterval {
     return self < a ? a : (self > b ? b : self)
   }
 }
-extension CGPoint {
-  internal func translate(_ dx: CGFloat, dy: CGFloat) -> CGPoint {
+
+internal extension CGPoint {
+  func translate(_ dx: CGFloat, dy: CGFloat) -> CGPoint {
     return CGPoint(x: self.x + dx, y: self.y + dy)
   }
 
-  internal func transform(_ t: CGAffineTransform) -> CGPoint {
+  func transform(_ t: CGAffineTransform) -> CGPoint {
     return self.applying(t)
   }
 
-  internal func transform(_ t: CATransform3D) -> CGPoint {
+  func transform(_ t: CATransform3D) -> CGPoint {
     return self.applying(CATransform3DGetAffineTransform(t))
   }
 
-  internal func distance(_ b: CGPoint) -> CGFloat {
+  func distance(_ b: CGPoint) -> CGFloat {
     return sqrt(pow(self.x - b.x, 2) + pow(self.y - b.y, 2))
   }
 
-  internal static func + (left: CGPoint, right: CGPoint) -> CGPoint {
+  static func + (left: CGPoint, right: CGPoint) -> CGPoint {
     return CGPoint(x: left.x + right.x, y: left.y + right.y)
   }
 
-  internal static func - (left: CGPoint, right: CGPoint) -> CGPoint {
+  static func - (left: CGPoint, right: CGPoint) -> CGPoint {
     return CGPoint(x: left.x - right.x, y: left.y - right.y)
   }
 
-  internal static func / (left: CGPoint, right: CGFloat) -> CGPoint {
+  static func / (left: CGPoint, right: CGFloat) -> CGPoint {
     return CGPoint(x: left.x / right, y: left.y / right)
   }
-  internal static func / (left: CGPoint, right: CGPoint) -> CGPoint {
+  static func / (left: CGPoint, right: CGPoint) -> CGPoint {
     return CGPoint(x: left.x / right.x, y: left.y / right.y)
   }
-  internal static func * (left: CGPoint, right: CGFloat) -> CGPoint {
+  static func * (left: CGPoint, right: CGFloat) -> CGPoint {
     return CGPoint(x: left.x * right, y: left.y * right)
   }
-  internal static func * (left: CGPoint, right: CGSize) -> CGPoint {
+  static func * (left: CGPoint, right: CGSize) -> CGPoint {
     return CGPoint(x: left.x * right.width, y: left.y * right.height)
   }
-  internal static func * (left: CGFloat, right: CGPoint) -> CGPoint {
+  static func * (left: CGFloat, right: CGPoint) -> CGPoint {
     return right * left
   }
 
-  internal static func * (left: CGPoint, right: CGPoint) -> CGPoint {
+  static func * (left: CGPoint, right: CGPoint) -> CGPoint {
     return CGPoint(x: left.x * right.x, y: left.y * right.y)
   }
 
-  internal static prefix func - (point: CGPoint) -> CGPoint {
+  static prefix func - (point: CGPoint) -> CGPoint {
     return .zero - point
   }
 
-  internal static func abs(_ p: CGPoint) -> CGPoint {
+  static func abs(_ p: CGPoint) -> CGPoint {
     return CGPoint(x: Swift.abs(p.x), y: Swift.abs(p.y))
   }
 }
 
-extension CGSize {
-  internal static func * (left: CGSize, right: CGFloat) -> CGSize {
+internal extension CGSize {
+  static func * (left: CGSize, right: CGFloat) -> CGSize {
     return CGSize(width: left.width * right, height: left.height * right)
   }
-  internal static func * (left: CGSize, right: CGSize) -> CGSize {
+  static func * (left: CGSize, right: CGSize) -> CGSize {
     return CGSize(width: left.width * right.width, height: left.height * right.height)
   }
-  internal static func / (left: CGSize, right: CGSize) -> CGSize {
+  static func / (left: CGSize, right: CGSize) -> CGSize {
     return CGSize(width: left.width / right.width, height: left.height / right.height)
   }
-  internal static func / (left: CGPoint, right: CGSize) -> CGPoint {
+  static func / (left: CGPoint, right: CGSize) -> CGPoint {
     return CGPoint(x: left.x / right.width, y: left.y / right.height)
   }
 }

--- a/Sources/Extensions/UIView+Hero.swift
+++ b/Sources/Extensions/UIView+Hero.swift
@@ -49,7 +49,7 @@ public extension HeroExtension where Base: UIView {
    Whenever a pair is discovered,
    Hero will automatically transit the views from source state to the destination state.
    */
-   public var id: String? {
+   var id: String? {
     get { return objc_getAssociatedObject(base, &type(of: base).AssociatedKeys.heroID) as? String }
     set { objc_setAssociatedObject(base, &type(of: base).AssociatedKeys.heroID, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
   }
@@ -58,7 +58,7 @@ public extension HeroExtension where Base: UIView {
    **isEnabled** allows to specify whether a view and its subviews should be consider for animations.
    If true, Hero will search through all the subviews for heroIds and modifiers. Defaults to true
    */
-  public var isEnabled: Bool {
+  var isEnabled: Bool {
     get { return objc_getAssociatedObject(base, &type(of: base).AssociatedKeys.heroEnabled) as? Bool ?? true }
     set { objc_setAssociatedObject(base, &type(of: base).AssociatedKeys.heroEnabled, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
   }
@@ -67,7 +67,7 @@ public extension HeroExtension where Base: UIView {
    **isEnabledForSubviews** allows to specify whether a view's subviews should be consider for animations.
    If true, Hero will search through all the subviews for heroIds and modifiers. Defaults to true
    */
-  public var isEnabledForSubviews: Bool {
+  var isEnabledForSubviews: Bool {
     get { return objc_getAssociatedObject(base, &type(of: base).AssociatedKeys.heroEnabledForSubviews) as? Bool ?? true }
     set { objc_setAssociatedObject(base, &type(of: base).AssociatedKeys.heroEnabledForSubviews, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
   }
@@ -75,7 +75,7 @@ public extension HeroExtension where Base: UIView {
   /**
    Use **modifiers** to specify animations alongside the main transition. Checkout `HeroModifier.swift` for available modifiers.
    */
-  public var modifiers: [HeroModifier]? {
+  var modifiers: [HeroModifier]? {
     get { return objc_getAssociatedObject(base, &type(of: base).AssociatedKeys.heroModifiers) as? [HeroModifier] }
     set { objc_setAssociatedObject(base, &type(of: base).AssociatedKeys.heroModifiers, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
   }
@@ -83,7 +83,7 @@ public extension HeroExtension where Base: UIView {
   /**
    **modifierString** provides another way to set **modifiers**. It can be assigned through storyboard.
    */
-  public var modifierString: String? {
+  var modifierString: String? {
     get { fatalError("Reverse lookup is not supported") }
     set { modifiers = newValue?.parse() }
   }
@@ -137,7 +137,7 @@ public extension UIView {
   }
 
   @available(*, deprecated, message: "Use hero.modifiers instead")
-  public var heroModifiers: [HeroModifier]? {
+  var heroModifiers: [HeroModifier]? {
     get { return hero.modifiers }
     set { hero.modifiers = newValue }
   }

--- a/Sources/Extensions/UIViewController+Hero.swift
+++ b/Sources/Extensions/UIViewController+Hero.swift
@@ -54,19 +54,19 @@ public extension HeroExtension where Base: UIViewController {
   }
 
   /// default hero animation type for presenting & dismissing modally
-  public var modalAnimationType: HeroDefaultAnimationType {
+  var modalAnimationType: HeroDefaultAnimationType {
     get { return config.modalAnimation }
     set { config.modalAnimation = newValue }
   }
 
   // TODO: can be moved to internal later (will still be accessible via IB)
-  public var modalAnimationTypeString: String? {
+  var modalAnimationTypeString: String? {
     get { return config.modalAnimation.label }
     set { config.modalAnimation = newValue?.parseOne() ?? .auto }
   }
 
   // TODO: can be moved to internal later (will still be accessible via IB)
-  public var isEnabled: Bool {
+  var isEnabled: Bool {
     get {
       return base.transitioningDelegate is HeroTransition
     }
@@ -123,19 +123,19 @@ public extension UIViewController {
   }
 
   @available(*, deprecated, message: "Use hero.modalAnimationType instead")
-  public var heroModalAnimationType: HeroDefaultAnimationType {
+  var heroModalAnimationType: HeroDefaultAnimationType {
     get { return hero.modalAnimationType }
     set { hero.modalAnimationType = newValue }
   }
 
   @available(*, deprecated, message: "Use hero.modalAnimationTypeString instead")
-  @IBInspectable public var heroModalAnimationTypeString: String? {
+  @IBInspectable var heroModalAnimationTypeString: String? {
     get { return hero.modalAnimationTypeString }
     set { hero.modalAnimationTypeString = newValue }
   }
 
   @available(*, deprecated, message: "Use hero.isEnabled instead")
-  @IBInspectable public var isHeroEnabled: Bool {
+  @IBInspectable var isHeroEnabled: Bool {
     get { return hero.isEnabled }
     set { hero.isEnabled = newValue }
   }
@@ -144,12 +144,12 @@ public extension UIViewController {
 public extension HeroExtension where Base: UINavigationController {
 
   /// default hero animation type for push and pop within the navigation controller
-  public var navigationAnimationType: HeroDefaultAnimationType {
+  var navigationAnimationType: HeroDefaultAnimationType {
     get { return config.navigationAnimation }
     set { config.navigationAnimation = newValue }
   }
 
-  public var navigationAnimationTypeString: String? {
+  var navigationAnimationTypeString: String? {
     get { return config.navigationAnimation.label }
     set { config.navigationAnimation = newValue?.parseOne() ?? .auto }
   }
@@ -173,27 +173,27 @@ extension UINavigationController {
 public extension HeroExtension where Base: UITabBarController {
 
   /// default hero animation type for switching tabs within the tab bar controller
-  public var tabBarAnimationType: HeroDefaultAnimationType {
+  var tabBarAnimationType: HeroDefaultAnimationType {
     get { return config.tabBarAnimation }
     set { config.tabBarAnimation = newValue }
   }
 
-  public var tabBarAnimationTypeString: String? {
+  var tabBarAnimationTypeString: String? {
     get { return config.tabBarAnimation.label }
     set { config.tabBarAnimation = newValue?.parseOne() ?? .auto }
   }
 }
 
-extension UITabBarController {
+public extension UITabBarController {
   @available(*, deprecated, message: "Use hero.tabBarAnimationType instead")
-  public var heroTabBarAnimationType: HeroDefaultAnimationType {
+  var heroTabBarAnimationType: HeroDefaultAnimationType {
     get { return hero.tabBarAnimationType }
     set { hero.tabBarAnimationType = newValue }
   }
 
   // TODO: can be moved to internal later (will still be accessible via IB)
   @available(*, deprecated, message: "Use hero.tabBarAnimationTypeString instead")
-  @IBInspectable public var heroTabBarAnimationTypeString: String? {
+  @IBInspectable var heroTabBarAnimationTypeString: String? {
     get { return hero.tabBarAnimationTypeString }
     set { hero.tabBarAnimationTypeString = newValue }
   }
@@ -205,7 +205,7 @@ public extension HeroExtension where Base: UIViewController {
    Dismiss the current view controller with animation. Will perform a navigationController.popViewController
    if the current view controller is contained inside a navigationController
    */
-  public func dismissViewController(completion: (() -> Void)? = nil) {
+  func dismissViewController(completion: (() -> Void)? = nil) {
     if let navigationController = base.navigationController, navigationController.viewControllers.first != base {
       navigationController.popViewController(animated: true)
     } else {
@@ -216,32 +216,32 @@ public extension HeroExtension where Base: UIViewController {
   /**
    Unwind to the root view controller using Hero
    */
-  public func unwindToRootViewController() {
+  func unwindToRootViewController() {
     unwindToViewController { $0.presentingViewController == nil }
   }
 
   /**
    Unwind to a specific view controller using Hero
    */
-  public func unwindToViewController(_ toViewController: UIViewController) {
+  func unwindToViewController(_ toViewController: UIViewController) {
     unwindToViewController { $0 == toViewController }
   }
 
-  public func unwindToViewController(withSelector: Selector) {
+  func unwindToViewController(withSelector: Selector) {
     unwindToViewController { $0.responds(to: withSelector) }
   }
 
   /**
    Unwind to a view controller with given class using Hero
    */
-  public func unwindToViewController(withClass: AnyClass) {
+  func unwindToViewController(withClass: AnyClass) {
     unwindToViewController { $0.isKind(of: withClass) }
   }
 
   /**
    Unwind to a view controller that the matchBlock returns true on.
    */
-  public func unwindToViewController(withMatchBlock: (UIViewController) -> Bool) {
+  func unwindToViewController(withMatchBlock: (UIViewController) -> Bool) {
     var target: UIViewController? = nil
     var current: UIViewController? = base
 
@@ -295,7 +295,7 @@ public extension HeroExtension where Base: UIViewController {
   /**
    Replace the current view controller with another VC on the navigation/modal stack.
    */
-  public func replaceViewController(with next: UIViewController, completion: (() -> Void)? = nil) {
+  func replaceViewController(with next: UIViewController, completion: (() -> Void)? = nil) {
     let hero = next.transitioningDelegate as? HeroTransition ?? Hero.shared
 
     if hero.isTransitioning {
@@ -332,12 +332,12 @@ public extension HeroExtension where Base: UIViewController {
 }
 
 extension UIViewController {
-  @available(*, deprecated: 0.1.4, message: "use hero.dismissViewController instead")
+  @available(*, deprecated, message: "use hero.dismissViewController instead")
   @IBAction public func ht_dismiss(_ sender: UIView) {
     hero.dismissViewController()
   }
 
-  @available(*, deprecated: 0.1.4, message: "use hero.replaceViewController(with:) instead")
+  @available(*, deprecated, message: "use hero.replaceViewController(with:) instead")
   public func heroReplaceViewController(with next: UIViewController) {
     hero.replaceViewController(with: next)
   }

--- a/Sources/HeroCompatible.swift
+++ b/Sources/HeroCompatible.swift
@@ -29,7 +29,7 @@ public protocol HeroCompatible {
 }
 
 public extension HeroCompatible {
-  public var hero: HeroExtension<Self> {
+  var hero: HeroExtension<Self> {
     get { return HeroExtension(self) }
     set { }
   }

--- a/Sources/Parser/Regex.swift
+++ b/Sources/Parser/Regex.swift
@@ -10,7 +10,7 @@ import Foundation
 
 var expressions = [String: NSRegularExpression]()
 public extension String {
-  public func match(regex: String) -> (String, CountableRange<Int>)? {
+  func match(regex: String) -> (String, CountableRange<Int>)? {
     let expression: NSRegularExpression
     if let exists = expressions[regex] {
       expression = exists

--- a/Sources/Transition/HeroTransition+CustomTransition.swift
+++ b/Sources/Transition/HeroTransition+CustomTransition.swift
@@ -24,7 +24,7 @@ import UIKit
 
 // custom transition helper, used in hero_replaceViewController
 public extension HeroTransition {
-  public func transition(from: UIViewController, to: UIViewController, in view: UIView, completion: ((Bool) -> Void)? = nil) {
+  func transition(from: UIViewController, to: UIViewController, in view: UIView, completion: ((Bool) -> Void)? = nil) {
     guard !isTransitioning else { return }
     self.state = .notified
     isPresenting = true


### PR DESCRIPTION
Hero causes excessive and unnecessary warning loggings for redundant access modifier information, for instance when building apps that use it on Bitrise. It also warns about the version number in two deprecations.

Removing access modifiers that match their enclosing extension makes these warnings go away. I also removed the version number in the deprecations.

The PR has no functional changes.