### PR TITLE
Enabled Examples building on Xcode 11

### DIFF
--- a/Examples/ExampleBaseViewController.swift
+++ b/Examples/ExampleBaseViewController.swift
@@ -10,6 +10,16 @@ import UIKit
 
 // basically a view controller with a back button and a tap gesture configured
 class ExampleBaseViewController: UIViewController {
+  
+  init() {
+    super.init(nibName: nil, bundle: nil)
+    modalPresentationStyle = .overFullScreen
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
   let dismissButton = UIButton(type: .system)
 
   override func viewDidLoad() {

--- a/Hero.xcodeproj/project.pbxproj
+++ b/Hero.xcodeproj/project.pbxproj
@@ -916,7 +916,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-HeroExamples/Pods-HeroExamples-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-HeroExamples/Pods-HeroExamples-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/ChameleonFramework/ChameleonFramework.framework",
 				"${BUILT_PRODUCTS_DIR}/CollectionKit/CollectionKit.framework",
 			);
@@ -927,7 +927,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-HeroExamples/Pods-HeroExamples-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HeroExamples/Pods-HeroExamples-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		89DC76B30A0BF7FD724C24D3 /* [CP] Check Pods Manifest.lock */ = {

--- a/LegacyExamples/Examples/BuiltInTransition/AnimationSelectTableViewController.swift
+++ b/LegacyExamples/Examples/BuiltInTransition/AnimationSelectTableViewController.swift
@@ -51,7 +51,7 @@ class AnimationSelectTableViewController: UITableViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    tableView.backgroundColor = UIColor.randomFlat
+    tableView.backgroundColor = UIColor.randomFlat()
     labelColor = UIColor(contrastingBlackOrWhiteColorOn: tableView.backgroundColor!, isFlat: true)
     let screenEdgePanGR = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handlePan(gr:)))
     screenEdgePanGR.edges = .left

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ target 'HeroExamples' do
   platform :ios, '9.0'
   use_frameworks!
   pod "CollectionKit"
-  pod 'ChameleonFramework/Swift', :git => 'https://github.com/ViccAlexander/Chameleon.git'
+  pod 'ChameleonFramework/Swift', :git => 'https://github.com/wowansm/Chameleon.git', :branch => 'swift5'
 end
 
 target 'HeroTvOSExamples' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,26 +7,27 @@ PODS:
   - CollectionKit/Core (2.2.0)
 
 DEPENDENCIES:
-  - ChameleonFramework/Swift (from `https://github.com/ViccAlexander/Chameleon.git`)
+  - ChameleonFramework/Swift (from `https://github.com/wowansm/Chameleon.git`, branch `swift5`)
   - CollectionKit
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - CollectionKit
 
 EXTERNAL SOURCES:
   ChameleonFramework:
-    :git: https://github.com/ViccAlexander/Chameleon.git
+    :branch: swift5
+    :git: https://github.com/wowansm/Chameleon.git
 
 CHECKOUT OPTIONS:
   ChameleonFramework:
-    :commit: 6dd284bde21ea2e7f9fd89bc36f40df16e16369d
-    :git: https://github.com/ViccAlexander/Chameleon.git
+    :commit: 96d52c36a45847fff60bcff7a58fec1e4bd7390b
+    :git: https://github.com/wowansm/Chameleon.git
 
 SPEC CHECKSUMS:
   ChameleonFramework: d21a3cc247abfe5e37609a283a8238b03575cf64
   CollectionKit: 5caa5341860d4c9b748ebfeaab97530b2d02c7c0
 
-PODFILE CHECKSUM: 126cdb5cfac9a9e2d2e798696131fd8758b6c34d
+PODFILE CHECKSUM: dd3255f57bc2d0e63ad0095225304694e193dc68
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.8.0


### PR DESCRIPTION
Enabled building for examples with Xcode 11. We should remove Chameleon Pod, as it is no longer maintained.