### PR TITLE
CODEOWNERS and auto_assign.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# https://help.github.com/en/articles/about-code-owners
+
+# These owners will be the default owners for everything in the repo.
+*       @JoeMatt @lkzhao @SD10 @kuyazee

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,29 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - JoeMatt
+  - lkzhao
+  - SD10
+  - kuyazee
+  
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of assignees, overrides reviewers if set
+# assignees:
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+numberOfAssignees: 1
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip
+  - WIP


### PR DESCRIPTION
Add CODEOWNERS to require a code owner approval for PR merge
Add auto_assign.yml so auto-assign bot can auto add maintainers for PR reviews