### PR TITLE
Fix for #640: UITableViewAlertForLayoutOutsideViewHierarchy Warning

### DIFF
--- a/Sources/Transition/HeroTransition+Start.swift
+++ b/Sources/Transition/HeroTransition+Start.swift
@@ -34,7 +34,9 @@ extension HeroTransition {
         toView.frame = fromView.frame
       }
       toView.setNeedsLayout()
-      toView.layoutIfNeeded()
+      if nil != toView.window {
+        toView.layoutIfNeeded()
+      }
     }
 
     if let fvc = fromViewController, let tvc = toViewController {


### PR DESCRIPTION
This PR applies cfaf2e4588aaf1efa5a3149744ccff07fe4540cc from aragevorkian/Hero.
This fixes #640, tested on iOS 13.5