### PR TITLE
Fixes unarchiveObject(with:) and archivedData(withRootObject:) deprecated in iOS 12.0

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,20 @@
+name: Swift Lint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - '.swiftlint.yml'
+      - '**/*.swift'
+
+jobs:
+  swift-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: GitHub Action for SwiftLint
+        uses: norio-nomura/action-swiftlint@3.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIFF_BASE: ${{ github.base_ref }}

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - CollectionKit
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - CollectionKit
 
 SPEC CHECKSUMS:

--- a/Sources/Extensions/UIKit+Hero.swift
+++ b/Sources/Extensions/UIKit+Hero.swift
@@ -27,9 +27,13 @@ import UIKit
 private let parameterRegex = "(?:\\-?\\d+(\\.?\\d+)?)|\\w+"
 private let modifiersRegex = "(\\w+)(?:\\(([^\\)]*)\\))?"
 
-internal extension NSObject {
+internal extension NSCoding where Self: NSObject {
   func copyWithArchiver() -> Any? {
-    return NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: self))!
+		if #available(iOS 11.0, *) {
+			return try? NSKeyedUnarchiver.unarchivedObject(ofClass: type(of: self), from: NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false))
+		} else {
+			return NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: self))!
+		}
   }
 }
 

--- a/Sources/Extensions/UIKit+Hero.swift
+++ b/Sources/Extensions/UIKit+Hero.swift
@@ -29,7 +29,7 @@ private let modifiersRegex = "(\\w+)(?:\\(([^\\)]*)\\))?"
 
 internal extension NSCoding where Self: NSObject {
   func copyWithArchiver() -> Any? {
-		if #available(iOS 11.0, *) {
+		if #available(iOS 11.0, tvOS 11.0, *) {
 			return try? NSKeyedUnarchiver.unarchivedObject(ofClass: type(of: self), from: NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false))
 		} else {
 			return NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: self))!

--- a/Sources/SwiftSupport.swift
+++ b/Sources/SwiftSupport.swift
@@ -12,7 +12,7 @@ import CoreMedia
 import CoreGraphics
 
 extension CMTime {
-  static let zero = CMTime.zero
+	static let zero = kCMTimeZero
 }
 
 enum CAMediaTimingFillMode {
@@ -46,7 +46,7 @@ extension UIViewController {
 
 extension RunLoop {
   enum Mode {
-    static let common = RunLoop.Mode.common
+		static let common = RunLoopMode.commonModes
   }
 }
 


### PR DESCRIPTION
#691